### PR TITLE
fix: Space bar now emits space

### DIFF
--- a/source.c
+++ b/source.c
@@ -97,8 +97,13 @@ static void key_pressed(GtkWidget *button, gpointer user_data) {
         }
         create_keys(win, VIRTUAL_KEYBOARD(win)->current_layout);
       } else {
-        g_signal_emit_by_name((GTK_ENTRY(win->input_field)), "insert-at-cursor",
-                              key_data->label);
+        if (key_data->code == KEY_SPACE) {
+          g_signal_emit_by_name((GTK_ENTRY(win->input_field)),
+                "insert-at-cursor", " ");
+        } else {
+          g_signal_emit_by_name((GTK_ENTRY(win->input_field)),
+                "insert-at-cursor", key_data->label);
+        }
       }
     }
   } else if (key_data->type == BackLayer) {


### PR DESCRIPTION
@progandy Thank you for this useful module for gtklock!

Without this fix, space bar, as a regular key emits its label, which is an empty string for the space bar in all keyboard layouts. 

This PR makes an exception for `KEY_SPACE` code (without SHIFT) and emits space `" "`.

